### PR TITLE
Feat/fp 117 User 인증 로직 전면수정(reissue, RTR 적용 등)

### DIFF
--- a/src/main/java/com/develonity/InitData.java
+++ b/src/main/java/com/develonity/InitData.java
@@ -1,0 +1,23 @@
+package com.develonity;
+
+import com.develonity.admin.entity.Admin;
+import com.develonity.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InitData implements ApplicationRunner {
+
+  private final AdminRepository adminRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  @Override
+  public void run(ApplicationArguments args) throws Exception {
+    Admin admin = new Admin("admin", passwordEncoder.encode("admin"));
+    adminRepository.save(admin);
+  }
+}

--- a/src/main/java/com/develonity/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/develonity/admin/controller/AdminAuthController.java
@@ -1,0 +1,37 @@
+package com.develonity.admin.controller;
+
+import com.develonity.admin.service.AdminAuthService;
+import com.develonity.common.jwt.JwtUtil;
+import com.develonity.user.dto.LoginRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admins")
+public class AdminAuthController {
+
+  private final AdminAuthService adminAuthService;
+
+  @PostMapping("/login")
+  public ResponseEntity<String> login(@RequestBody LoginRequest loginRequest,
+      HttpServletResponse httpServletResponse) {
+    String adminAccessToken = adminAuthService.login(loginRequest);
+    httpServletResponse.addHeader(JwtUtil.ADMIN_HEADER, adminAccessToken);
+    return new ResponseEntity<>("로그인 성공", HttpStatus.OK);
+  }
+
+  @PostMapping("/register")
+  public ResponseEntity<String> register(@RequestBody LoginRequest loginRequest) {
+    adminAuthService.register(loginRequest);
+    return new ResponseEntity<>("등록 성공", HttpStatus.CREATED);
+
+  }
+
+}

--- a/src/main/java/com/develonity/admin/entity/Admin.java
+++ b/src/main/java/com/develonity/admin/entity/Admin.java
@@ -1,6 +1,5 @@
 package com.develonity.admin.entity;
 
-import com.develonity.user.entity.UserRole;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -23,7 +22,7 @@ public class Admin {
 
   @Column(nullable = false)
   @Enumerated(value = EnumType.STRING)
-  private UserRole role = UserRole.ADMIN;
+  private AdminRole role = AdminRole.ADMIN;
   @Column(nullable = false, unique = true)
   private String loginId;
   @Column(nullable = false)

--- a/src/main/java/com/develonity/admin/entity/Admin.java
+++ b/src/main/java/com/develonity/admin/entity/Admin.java
@@ -1,0 +1,36 @@
+package com.develonity.admin.entity;
+
+import com.develonity.user.entity.UserRole;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Admin {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  @Enumerated(value = EnumType.STRING)
+  private UserRole role = UserRole.ADMIN;
+  @Column(nullable = false, unique = true)
+  private String loginId;
+  @Column(nullable = false)
+  private String password;
+
+  public Admin(String loginId, String password) {
+    this.loginId = loginId;
+    this.password = password;
+  }
+}

--- a/src/main/java/com/develonity/admin/entity/AdminRole.java
+++ b/src/main/java/com/develonity/admin/entity/AdminRole.java
@@ -1,0 +1,20 @@
+package com.develonity.admin.entity;
+
+public enum AdminRole {
+  ADMIN(Authority.ADMIN);  // 관리자 권한
+  private final String authority;
+
+  AdminRole(String authority) {
+    this.authority = authority;
+  }
+
+  public String getAuthority() {
+    return authority;
+  }
+
+  public static class Authority {
+
+    public static final String ADMIN = "ROLE_ADMIN";
+  }
+
+}

--- a/src/main/java/com/develonity/admin/repository/AdminRepository.java
+++ b/src/main/java/com/develonity/admin/repository/AdminRepository.java
@@ -1,0 +1,11 @@
+package com.develonity.admin.repository;
+
+import com.develonity.admin.entity.Admin;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+  Optional<Admin> findByLoginId(String loginId);
+
+}

--- a/src/main/java/com/develonity/admin/service/AdminAuthService.java
+++ b/src/main/java/com/develonity/admin/service/AdminAuthService.java
@@ -1,0 +1,35 @@
+package com.develonity.admin.service;
+
+import com.develonity.admin.entity.Admin;
+import com.develonity.admin.repository.AdminRepository;
+import com.develonity.common.jwt.JwtUtil;
+import com.develonity.user.dto.LoginRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService {
+
+  private final AdminRepository adminRepository;
+  private final PasswordEncoder passwordEncoder;
+  private final JwtUtil jwtUtil;
+
+  @Transactional
+  public String login(LoginRequest loginRequest) {
+    Admin admin = adminRepository.findByLoginId(loginRequest.getLoginId())
+        .orElseThrow(IllegalArgumentException::new);
+    if (!passwordEncoder.matches(loginRequest.getPassword(), admin.getPassword())) {
+      throw new IllegalArgumentException("비밀번호 불일치");
+    }
+    return jwtUtil.createAccessToken(admin.getLoginId(), admin.getRole());
+  }
+
+  @Transactional
+  public void register(LoginRequest loginRequest) {
+    String encodingPassword = passwordEncoder.encode(loginRequest.getPassword());
+    adminRepository.save(new Admin(loginRequest.getLoginId(), encodingPassword));
+  }
+}

--- a/src/main/java/com/develonity/admin/service/AdminAuthService.java
+++ b/src/main/java/com/develonity/admin/service/AdminAuthService.java
@@ -24,7 +24,7 @@ public class AdminAuthService {
     if (!passwordEncoder.matches(loginRequest.getPassword(), admin.getPassword())) {
       throw new IllegalArgumentException("비밀번호 불일치");
     }
-    return jwtUtil.createAccessToken(admin.getLoginId(), admin.getRole());
+    return jwtUtil.createAdminToken(admin.getLoginId(), admin.getRole());
   }
 
   @Transactional

--- a/src/main/java/com/develonity/board/dto/QuestionBoardResponse.java
+++ b/src/main/java/com/develonity/board/dto/QuestionBoardResponse.java
@@ -26,7 +26,7 @@ public class QuestionBoardResponse {
 
   public QuestionBoardResponse(QuestionBoard questionBoard, User user, int boardLike) {
     this.id = questionBoard.getId();
-    this.nickname = user.getNickName();
+    this.nickname = user.getNickname();
     this.category = questionBoard.getCategory();
     this.title = questionBoard.getTitle();
     this.content = questionBoard.getContent();
@@ -36,7 +36,7 @@ public class QuestionBoardResponse {
     this.createdAt = questionBoard.getCreatedDate();
     this.lastModifiedAt = questionBoard.getLastModifiedDate();
 
-    
+
   }
 
 

--- a/src/main/java/com/develonity/comment/entity/Comment.java
+++ b/src/main/java/com/develonity/comment/entity/Comment.java
@@ -49,7 +49,7 @@ public class Comment extends TimeStamp {
 
 
   public Comment(User user, CommentRequest requestDto) {
-    this.nickName = user.getNickName();
+    this.nickName = user.getNickname();
     this.content = requestDto.getContent();
     this.point = user.getGiftPoint();
     this.user = user;

--- a/src/main/java/com/develonity/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/develonity/comment/service/CommentServiceImpl.java
@@ -31,7 +31,7 @@ public class CommentServiceImpl implements CommentService {
 
   // 작성자와 현재 유저가 같은지 확인하는 기능
   private void checkUser(User user, Comment comment) {
-    if (comment.getNickName() != user.getNickName()) {
+    if (comment.getNickName() != user.getNickname()) {
       throw new CustomException(ExceptionStatus.COMMENT_USER_NOT_MATCH);
     }
   }
@@ -56,7 +56,7 @@ public class CommentServiceImpl implements CommentService {
     }
 
     Page<Comment> myCommentList = commentRepository.findAllByNickName(commentList.toPageable(),
-        user.getNickName());
+        user.getNickname());
     return myCommentList.map(
         comment1 -> new CommentResponse(comment1, commentLikeService.addLike(comment1.getId())));
   }

--- a/src/main/java/com/develonity/common/jwt/AdminAuthFilter.java
+++ b/src/main/java/com/develonity/common/jwt/AdminAuthFilter.java
@@ -21,8 +21,8 @@ public class AdminAuthFilter extends OncePerRequestFilter {
     try {
       String adminToken = jwtUtil.resolveAdminToken(request);
       if (adminToken != null) {
-        String username = jwtUtil.getUsernameFromTokenIfValid(adminToken);
-        Authentication authentication = jwtUtil.createAuthentication(username,
+        String loginId = jwtUtil.getLoginIdFromTokenIfValid(adminToken);
+        Authentication authentication = jwtUtil.createAuthentication(loginId,
             "adminDetailsService");
         SecurityContextHolder.getContext().setAuthentication(authentication);
       }

--- a/src/main/java/com/develonity/common/jwt/AdminAuthFilter.java
+++ b/src/main/java/com/develonity/common/jwt/AdminAuthFilter.java
@@ -1,0 +1,35 @@
+package com.develonity.common.jwt;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class AdminAuthFilter extends OncePerRequestFilter {
+
+  private final JwtUtil jwtUtil;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    try {
+      String adminToken = jwtUtil.resolveAdminToken(request);
+      if (adminToken != null) {
+        String username = jwtUtil.getUsernameFromTokenIfValid(adminToken);
+        Authentication authentication = jwtUtil.createAuthentication(username,
+            "adminDetailsService");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
+    } catch (Exception e) {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return;
+    }
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/develonity/common/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/develonity/common/jwt/JwtAuthFilter.java
@@ -22,11 +22,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
       FilterChain filterChain) throws ServletException, IOException {
     try {
       String accessToken = jwtUtil.resolveAccessToken(request);
-      String a = request.getRequestURI();
+      String adminToken = jwtUtil.resolveAdminToken(request);
+      if (adminToken != null) {
+        accessToken = adminToken;
+      }
       if (accessToken != null) {
-        // 이쯤에서 어드민 토큰 꺼내고 검증하는 로직이 있어야 할 것 같음(아래 로직 안타고 바로 .doFilter로 넘어가도록?)
         // accessToken에서 필요한 값(loginId, Role)과 토큰의 상태를 꺼냄
-        TokenInfo accessTokenInfo = jwtUtil.getInfoFromToken(accessToken);
+        TokenInfo accessTokenInfo = jwtUtil.getInfoFromTokenIfValidOrExpired(accessToken);
         if (accessTokenInfo.getJwtStatus() == JwtStatus.EXPIRED) {
           String refreshToken = JwtUtil.resolveRefreshToken(request);
           jwtUtil.checkBlackList(refreshToken);

--- a/src/main/java/com/develonity/common/jwt/JwtUtil.java
+++ b/src/main/java/com/develonity/common/jwt/JwtUtil.java
@@ -36,7 +36,7 @@ public class JwtUtil {
   public static final String ADMIN_HEADER = "Admin";
   public static final String AUTHORIZATION_KEY = "auth"; // 사용자 권한 키값. 사용자 권한도 토큰안에 넣어주기 때문에 그때 사용하는 키값
   private static final String BEARER_PREFIX = "Bearer "; // Token 식별자
-  private static final long ACCESS_TOKEN_TIME = 30 * 60 * 1000L;  // 토큰 만료시간. (60 * 1000L 이 1분)
+  private static final long ACCESS_TOKEN_TIME = 30 * 1000L;  // 토큰 만료시간. (60 * 1000L 이 1분)
   private static final long REFRESH_TOKEN_TIME = 2 * 7 * 24 * 60 * 60 * 1000L;
 
 
@@ -149,8 +149,8 @@ public class JwtUtil {
   public Long getValidMilliSeconds(String refreshToken) {
     Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(refreshToken)
         .getBody();
-    Long vaildSeconds = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
-    return vaildSeconds;
+    Long validSeconds = claims.getExpiration().getTime() - claims.getIssuedAt().getTime();
+    return validSeconds;
   }
 
   public void checkBlackList(String refreshToken) {

--- a/src/main/java/com/develonity/common/jwt/JwtUtil.java
+++ b/src/main/java/com/develonity/common/jwt/JwtUtil.java
@@ -31,6 +31,7 @@ public class JwtUtil {
   private final UserDetailsService userDetailsService;
   public static final String AUTHORIZATION_HEADER = "Authorization"; // access token 헤더에 들어가는 키값
   public static final String REFRESH_HEADER = "Refresh";
+  public static final String ADMIN_HEADER = "Admin";
   public static final String AUTHORIZATION_KEY = "auth"; // 사용자 권한 키값. 사용자 권한도 토큰안에 넣어주기 때문에 그때 사용하는 키값
   private static final String BEARER_PREFIX = "Bearer "; // Token 식별자
   private static final long ACCESS_TOKEN_TIME = 30 * 60 * 1000L;  // 토큰 만료시간. (60 * 1000L 이 1분)
@@ -61,6 +62,14 @@ public class JwtUtil {
 
   public static String resolveRefreshToken(HttpServletRequest request) {
     String bearerToken = request.getHeader(REFRESH_HEADER);
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+      return bearerToken.substring(7);
+    }
+    return null;
+  }
+
+  public String resolveAdminToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader(ADMIN_HEADER);
     if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
       return bearerToken.substring(7);
     }
@@ -98,7 +107,7 @@ public class JwtUtil {
   }
 
   // 단일책임원칙에는 위배되지만 jwt 디코딩 비용이 비싸므로 한큐에 모든결 해결하고 싶은 마음에 부득불 원칙을 어겼습니다.
-  public TokenInfo getInfoFromToken(String token) {
+  public TokenInfo getInfoFromTokenIfValidOrExpired(String token) {
     try {
       Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token)
           .getBody();
@@ -129,4 +138,6 @@ public class JwtUtil {
       throw new IllegalArgumentException("로그아웃 된 토큰입니다.");
     }
   }
+
+
 }

--- a/src/main/java/com/develonity/common/jwt/JwtUtil.java
+++ b/src/main/java/com/develonity/common/jwt/JwtUtil.java
@@ -36,8 +36,8 @@ public class JwtUtil {
   public static final String ADMIN_HEADER = "Admin";
   public static final String AUTHORIZATION_KEY = "auth"; // 사용자 권한 키값. 사용자 권한도 토큰안에 넣어주기 때문에 그때 사용하는 키값
   private static final String BEARER_PREFIX = "Bearer "; // Token 식별자
-  private static final long ACCESS_TOKEN_TIME = 30 * 1000L;  // 토큰 만료시간. (60 * 1000L 이 1분)
-  private static final long REFRESH_TOKEN_TIME = 2 * 7 * 24 * 60 * 60 * 1000L;
+  private static final long ACCESS_TOKEN_TIME = 30 * 60 * 1000L;  // 토큰 만료시간. (60 * 1000L 이 1분)
+  public static final long REFRESH_TOKEN_TIME = 2 * 7 * 24 * 60 * 60 * 1000L;
 
 
   @Value("${jwt.secret.key}")
@@ -134,7 +134,7 @@ public class JwtUtil {
     }
   }
 
-  public String getUsernameFromTokenIfValid(String token) {
+  public String getLoginIdFromTokenIfValid(String token) {
     return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody()
         .getSubject();
   }

--- a/src/main/java/com/develonity/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/develonity/common/security/config/SecurityConfig.java
@@ -1,7 +1,8 @@
 package com.develonity.common.security.config;
 
-import com.develonity.common.jwt.JwtAuthFilter;
+import com.develonity.common.jwt.AdminAuthFilter;
 import com.develonity.common.jwt.JwtUtil;
+import com.develonity.common.jwt.UserAuthFilter;
 import com.develonity.common.security.exceptionHandler.CustomAccessDeniedHandler;
 import com.develonity.common.security.exceptionHandler.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
@@ -62,7 +63,8 @@ public class SecurityConfig {
         .exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler())
         .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
         .and()
-        .addFilterBefore(new JwtAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        .addFilterBefore(new UserAuthFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(new AdminAuthFilter(jwtUtil), UserAuthFilter.class);
 
     return http.build();
   }

--- a/src/main/java/com/develonity/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/develonity/common/security/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
     http.authorizeHttpRequests()
         .antMatchers("/api/register").permitAll()
         .antMatchers("/api/login").permitAll()
+        .antMatchers("/api/admins/login").permitAll()
         .antMatchers("/api/logout").permitAll()
 //        .antMatchers("/api/users/signout").permitAll()
 //        .antMatchers("/api/users/**").hasRole("CUSTOMER")

--- a/src/main/java/com/develonity/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/develonity/common/security/config/SecurityConfig.java
@@ -54,7 +54,6 @@ public class SecurityConfig {
         .antMatchers("/api/register").permitAll()
         .antMatchers("/api/login").permitAll()
         .antMatchers("/api/admins/login").permitAll()
-        .antMatchers("/api/logout").permitAll()
         .antMatchers("/api/reissue").permitAll()
 //        .antMatchers("/api/users/signout").permitAll()
 //        .antMatchers("/api/users/**").hasRole("CUSTOMER")

--- a/src/main/java/com/develonity/common/security/config/SecurityConfig.java
+++ b/src/main/java/com/develonity/common/security/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
         .antMatchers("/api/login").permitAll()
         .antMatchers("/api/admins/login").permitAll()
         .antMatchers("/api/logout").permitAll()
+        .antMatchers("/api/reissue").permitAll()
 //        .antMatchers("/api/users/signout").permitAll()
 //        .antMatchers("/api/users/**").hasRole("CUSTOMER")
 //        .antMatchers("/api/sellers/**").hasRole("SELLER")

--- a/src/main/java/com/develonity/common/security/users/AdminDetails.java
+++ b/src/main/java/com/develonity/common/security/users/AdminDetails.java
@@ -1,0 +1,62 @@
+package com.develonity.common.security.users;
+
+import com.develonity.admin.entity.Admin;
+import com.develonity.user.entity.UserRole;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class AdminDetails implements UserDetails {
+
+  private final Admin admin;
+  private final String username;
+  private final Long adminId;
+
+  public AdminDetails(Admin admin, String username, Long adminId) {
+    this.admin = admin;
+    this.username = username;
+    this.adminId = adminId;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    UserRole role = admin.getRole();
+    String authority = role.getAuthority();
+    SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+    Collection<GrantedAuthority> authorities = new ArrayList<>();
+    authorities.add(simpleGrantedAuthority);
+    return authorities;
+  }
+
+  @Override
+  public String getPassword() {
+    return admin.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/src/main/java/com/develonity/common/security/users/AdminDetails.java
+++ b/src/main/java/com/develonity/common/security/users/AdminDetails.java
@@ -1,7 +1,7 @@
 package com.develonity.common.security.users;
 
 import com.develonity.admin.entity.Admin;
-import com.develonity.user.entity.UserRole;
+import com.develonity.admin.entity.AdminRole;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.springframework.security.core.GrantedAuthority;
@@ -22,7 +22,7 @@ public class AdminDetails implements UserDetails {
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    UserRole role = admin.getRole();
+    AdminRole role = admin.getRole();
     String authority = role.getAuthority();
     SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
     Collection<GrantedAuthority> authorities = new ArrayList<>();

--- a/src/main/java/com/develonity/common/security/users/AdminDetailsService.java
+++ b/src/main/java/com/develonity/common/security/users/AdminDetailsService.java
@@ -1,7 +1,7 @@
 package com.develonity.common.security.users;
 
-import com.develonity.user.entity.User;
-import com.develonity.user.repository.UserRepository;
+import com.develonity.admin.entity.Admin;
+import com.develonity.admin.repository.AdminRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -10,14 +10,15 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class UserDetailsServiceImpl implements UserDetailsService {
+public class AdminDetailsService implements UserDetailsService {
 
-  private final UserRepository userRepository;
+  private final AdminRepository adminRepository;
 
   @Override
   public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
-    User user = userRepository.findByLoginId(loginId)
-        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
-    return new UserDetailsImpl(user, loginId, user.getId());
+    Admin admin = adminRepository.findByLoginId(loginId)
+        .orElseThrow(() -> new UsernameNotFoundException("관리자를 찾을 수 없습니다."));
+    return new AdminDetails(admin, loginId, admin.getId());
   }
 }
+

--- a/src/main/java/com/develonity/common/security/users/UserDetailsServiceImpl.java
+++ b/src/main/java/com/develonity/common/security/users/UserDetailsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.develonity.common.security.users;
 
+import com.develonity.admin.entity.Admin;
+import com.develonity.admin.repository.AdminRepository;
 import com.develonity.user.entity.User;
 import com.develonity.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,12 +15,18 @@ import org.springframework.stereotype.Service;
 public class UserDetailsServiceImpl implements UserDetailsService {
 
   private final UserRepository userRepository;
+  private final AdminRepository adminRepository;
 
   @Override
   public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
-    User user = userRepository.findByLoginId(loginId)
-        .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
-
-    return new UserDetailsImpl(user, loginId, user.getId());
+    try {
+      User user = userRepository.findByLoginId(loginId)
+          .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+      return new UserDetailsImpl(user, loginId, user.getId());
+    } catch (Exception e) {
+      Admin admin = adminRepository.findByLoginId(loginId)
+          .orElseThrow(() -> new UsernameNotFoundException("관리자를 찾을 수 없습니다."));
+      return new AdminDetails(admin, loginId, admin.getId());
+    }
   }
 }

--- a/src/main/java/com/develonity/user/controller/UserController.java
+++ b/src/main/java/com/develonity/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.develonity.user.dto.LoginRequest;
 import com.develonity.user.dto.LoginResponse;
 import com.develonity.user.dto.ProfileResponse;
 import com.develonity.user.dto.RegisterRequest;
+import com.develonity.user.dto.ReissueResponse;
 import com.develonity.user.dto.WithdrawalRequest;
 import com.develonity.user.service.UserService;
 import javax.servlet.http.HttpServletRequest;
@@ -37,37 +38,33 @@ public class UserController {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<String> login(@RequestBody LoginRequest loginRequest,
+  public LoginResponse login(@RequestBody LoginRequest loginRequest,
       HttpServletResponse httpServletResponse) {
     LoginResponse loginResponse = userService.login(loginRequest);
+    // 44라인은 일단 포스트맨 테스트의 용이성을 위해 넣어두었습니다. 추후 프론트 구현 이후에는 삭제 예정입니다.
     httpServletResponse.addHeader(JwtUtil.AUTHORIZATION_HEADER, loginResponse.getAccessToken());
-    httpServletResponse.addHeader(JwtUtil.REFRESH_HEADER, loginResponse.getRefreshToken());
-    return new ResponseEntity<>("로그인 성공", HttpStatus.OK);
+    return loginResponse;
   }
 
   @PostMapping("/logout")
-  public ResponseEntity<String> logout(HttpServletRequest httpServletRequest,
-      HttpServletResponse httpServletResponse) {
+  public ResponseEntity<String> logout(HttpServletRequest httpServletRequest) {
     userService.logout(JwtUtil.resolveRefreshToken(httpServletRequest));
-
-    // response에 덮어씌우고자 하는 의도로 아래 두 라인을 작성하였음...
-    httpServletResponse.addHeader(JwtUtil.AUTHORIZATION_HEADER, "clear");
-    httpServletResponse.addHeader(JwtUtil.REFRESH_HEADER, "clear");
-
     return new ResponseEntity<>("로그아웃 성공", HttpStatus.OK);
   }
 
   @PatchMapping("/withdrawal")
   public ResponseEntity<String> withdrawal(@RequestBody WithdrawalRequest withdrawalRequest,
-      HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
-      @AuthenticationPrincipal UserDetailsImpl userDetails) {
+      HttpServletRequest httpServletRequest, @AuthenticationPrincipal UserDetailsImpl userDetails) {
     String refreshToken = JwtUtil.resolveRefreshToken(httpServletRequest);
     userService.withdrawal(refreshToken, userDetails.getUsername(),
         withdrawalRequest.getPassword());
-    // response에 덮어씌우고자 하는 의도로 아래 두 라인을 작성하였음...
-    httpServletResponse.addHeader(JwtUtil.AUTHORIZATION_HEADER, "clear");
-    httpServletResponse.addHeader(JwtUtil.REFRESH_HEADER, "clear");
     return new ResponseEntity<>("회원탈퇴 성공", HttpStatus.OK);
+  }
+
+  @PostMapping("/reissue")
+  public ReissueResponse reissue(HttpServletRequest httpServletRequest) {
+    String refreshToken = JwtUtil.resolveRefreshToken(httpServletRequest);
+    return userService.reissue(refreshToken);
   }
 
   // 내 프로필조회

--- a/src/main/java/com/develonity/user/controller/UserController.java
+++ b/src/main/java/com/develonity/user/controller/UserController.java
@@ -82,14 +82,15 @@ public class UserController {
     return userService.getProfile(userId);
   }
 
-//  //프로필 정보 수정 (닉네임, 프로필사진)
-//  @PutMapping("user/me/profile")
+  //내 프로필 정보 수정 (닉네임, 프로필사진)
+//  @PatchMapping("/users/me/profile")
+//  public
 //
 //  // 개인정보 조회 (이름, 비밀번호, 이메일, 핸드폰번호, 주소)
-//  @GetMapping("user/me/personal-information")
+//  @GetMapping("/users/me/personal-information")
 //
 //  // 개인정보 수정 (이름, 비밀번호, 이메일, 핸드폰번호, 주소)
-//  @PutMapping("user/me/personal-information")
+//  @PutMapping("/users/me/personal-information")
 
   // ----아래부터는 애매한 부분 ---
   //게시글 스크랩 저장 ?-? (이거는 애매함)

--- a/src/main/java/com/develonity/user/dto/ProfileResponse.java
+++ b/src/main/java/com/develonity/user/dto/ProfileResponse.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public class ProfileResponse {
 
   private final String profileImageUrl;
-  private final String nickName;
+  private final String nickname;
 
   // 나중에 프로필에 '등급점수' 추가돼도 괜찮을듯 합니다.
 

--- a/src/main/java/com/develonity/user/dto/RegisterRequest.java
+++ b/src/main/java/com/develonity/user/dto/RegisterRequest.java
@@ -20,7 +20,7 @@ public class RegisterRequest {
   private final String password;
   private final String realName;
   @Size(min = 2, max = 10)
-  private final String nickName;
+  private final String nickname;
   private final String profileImageUrl;
   private final String email;
   private final String phoneNumber;
@@ -33,7 +33,7 @@ public class RegisterRequest {
         .loginId(this.loginId)
         .password(encodingPassword)
         .realName(this.realName)
-        .nickName(this.nickName)
+        .nickname(this.nickname)
         .profileImageUrl(this.profileImageUrl)
         .email(this.email)
         .phoneNumber(this.phoneNumber)

--- a/src/main/java/com/develonity/user/dto/ReissueResponse.java
+++ b/src/main/java/com/develonity/user/dto/ReissueResponse.java
@@ -1,0 +1,12 @@
+package com.develonity.user.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ReissueResponse {
+
+  private final String accessToken;
+
+}

--- a/src/main/java/com/develonity/user/dto/TokenResponse.java
+++ b/src/main/java/com/develonity/user/dto/TokenResponse.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class LoginResponse {
+public class TokenResponse {
 
   private final String accessToken;
   private final String refreshToken;

--- a/src/main/java/com/develonity/user/entity/User.java
+++ b/src/main/java/com/develonity/user/entity/User.java
@@ -32,7 +32,7 @@ public class User extends TimeStamp {
   @Column(nullable = false)
   private String realName;
   @Column(nullable = false, unique = true)
-  private String nickName;
+  private String nickname;
   @Column(nullable = false)
   private String profileImageUrl;
   @Column(nullable = false, unique = true)
@@ -47,13 +47,13 @@ public class User extends TimeStamp {
   private int respectPoint = 0;
 
   @Builder
-  public User(String loginId, String password, String realName, String nickName,
+  public User(String loginId, String password, String realName, String nickname,
       String profileImageUrl, String email, String phoneNumber, String detailAddress,
       String zipcode) {
     this.loginId = loginId;
     this.password = password;
     this.realName = realName;
-    this.nickName = nickName;
+    this.nickname = nickname;
     this.profileImageUrl = profileImageUrl;
     this.email = email;
     this.phoneNumber = phoneNumber;

--- a/src/main/java/com/develonity/user/entity/UserRole.java
+++ b/src/main/java/com/develonity/user/entity/UserRole.java
@@ -2,8 +2,7 @@ package com.develonity.user.entity;
 
 public enum UserRole {
   AMATEUR(Authority.AMATEUR),  // 사용자 권한
-  EXPERT(Authority.EXPERT), // 전문가 권한
-  ADMIN(Authority.ADMIN);  // 관리자 권한
+  EXPERT(Authority.EXPERT); // 전문가 권한
   private final String authority;
 
   UserRole(String authority) {
@@ -18,7 +17,6 @@ public enum UserRole {
 
     public static final String AMATEUR = "ROLE_AMATEUR";
     public static final String EXPERT = "ROLE_EXPERT";
-    public static final String ADMIN = "ROLE_ADMIN";
   }
 
 }

--- a/src/main/java/com/develonity/user/service/UserService.java
+++ b/src/main/java/com/develonity/user/service/UserService.java
@@ -1,22 +1,21 @@
 package com.develonity.user.service;
 
 import com.develonity.user.dto.LoginRequest;
-import com.develonity.user.dto.LoginResponse;
 import com.develonity.user.dto.ProfileResponse;
 import com.develonity.user.dto.RegisterRequest;
-import com.develonity.user.dto.ReissueResponse;
+import com.develonity.user.dto.TokenResponse;
 
 public interface UserService {
 
   void register(RegisterRequest registerRequest);
 
-  LoginResponse login(LoginRequest loginRequest);
+  TokenResponse login(LoginRequest loginRequest);
 
-  void withdrawal(String refreshToken, String loginId, String password);
+  void withdrawal(String loginId, String password);
 
-  void logout(String refreshToken);
+  void logout(String loginId);
 
   ProfileResponse getProfile(Long userId);
 
-  ReissueResponse reissue(String refreshToken);
+  TokenResponse reissue(String refreshToken);
 }

--- a/src/main/java/com/develonity/user/service/UserService.java
+++ b/src/main/java/com/develonity/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.develonity.user.dto.LoginRequest;
 import com.develonity.user.dto.LoginResponse;
 import com.develonity.user.dto.ProfileResponse;
 import com.develonity.user.dto.RegisterRequest;
+import com.develonity.user.dto.ReissueResponse;
 
 public interface UserService {
 
@@ -16,4 +17,6 @@ public interface UserService {
   void logout(String refreshToken);
 
   ProfileResponse getProfile(Long userId);
+
+  ReissueResponse reissue(String refreshToken);
 }

--- a/src/main/java/com/develonity/user/service/UserServiceImpl.java
+++ b/src/main/java/com/develonity/user/service/UserServiceImpl.java
@@ -3,10 +3,9 @@ package com.develonity.user.service;
 import com.develonity.common.jwt.JwtUtil;
 import com.develonity.common.redis.RedisDao;
 import com.develonity.user.dto.LoginRequest;
-import com.develonity.user.dto.LoginResponse;
 import com.develonity.user.dto.ProfileResponse;
 import com.develonity.user.dto.RegisterRequest;
-import com.develonity.user.dto.ReissueResponse;
+import com.develonity.user.dto.TokenResponse;
 import com.develonity.user.entity.User;
 import com.develonity.user.repository.UserRepository;
 import java.time.Duration;
@@ -37,7 +36,7 @@ public class UserServiceImpl implements UserService {
 
   @Override
   @Transactional
-  public LoginResponse login(LoginRequest loginRequest) {
+  public TokenResponse login(LoginRequest loginRequest) {
     User user = userRepository.findByLoginId(loginRequest.getLoginId())
         .orElseThrow(IllegalArgumentException::new);
     if (user.isWithdrawal()) {
@@ -49,44 +48,69 @@ public class UserServiceImpl implements UserService {
 
     String accessToken = jwtUtil.createAccessToken(user.getLoginId(), user.getUserRole());
     String refreshToken = jwtUtil.createRefreshToken(user.getLoginId(), user.getUserRole());
-    return new LoginResponse(accessToken, refreshToken);
+    saveRefreshTokenToRedis(user.getLoginId(), refreshToken.substring(7));
+    return new TokenResponse(accessToken, refreshToken);
   }
 
   @Override
   @Transactional
-  public void logout(String refreshToken) {
-    Long validMilliSeconds = jwtUtil.getValidMilliSeconds(refreshToken);
-    redisDao.setValues(refreshToken, "", Duration.ofMillis(validMilliSeconds));
+  public void logout(String loginId) {
+    deleteRefreshTokenFromRedis(loginId);
   }
 
   @Override
   @Transactional
-  public void withdrawal(String refreshToken, String loginId, String password) {
+  public void withdrawal(String loginId, String password) {
     User user = userRepository.findByLoginId(loginId)
         .orElseThrow(IllegalArgumentException::new);
     if (!passwordEncoder.matches(password, user.getPassword())) {
       throw new IllegalArgumentException("비밀번호 불일치");
     }
     user.withdraw();
-    logout(refreshToken);
-  }
-
-  @Override
-  public ProfileResponse getProfile(Long userId) {
-    User user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
-    return new ProfileResponse(user.getProfileImageUrl(), user.getNickname());
+    deleteRefreshTokenFromRedis(loginId);
   }
 
   //   RTR(refresh token rotation)을 적용하려면 현재 블랙리스트로 운영중인 refresh token 운영방식을
 //   발급시 등록하는 체제로 수정해야한다.  그럼 모든 로그인 유저의 refresh token을 redis에 등록하고 관리해야한다....'
 //   근데 RTR을 안하고 지금 방식으로 가면 refreshToken으로 무한히 많은 access token을 발급할 수 있다는 문제가 있다.
+// 생각해보니 로그인 할 때마다 유효한 refreshToken이 계속 생긴다는 문제도 있다.
 //   RTR을 적용하면 refresh token이 탈취당하고 사용됐을 때 사용자가 서비스를 사용중이라면 알아차릴 수 있다.
   @Override
-  public ReissueResponse reissue(String refreshToken) {
-    jwtUtil.checkBlackList(refreshToken);
-    String username = jwtUtil.getUsernameFromTokenIfValid(refreshToken);
-    User user = userRepository.findByLoginId(username).orElseThrow(IllegalArgumentException::new);
+  @Transactional
+  public TokenResponse reissue(String refreshToken) {
+    String loginId = jwtUtil.getLoginIdFromTokenIfValid(refreshToken);
+    // 로그인, 리이슈 할 때마다 유효한 refresh token이 생겨나므로, redis에 있는 token과 동일한지 비교함으로써 가장 최근에 발급된 refresh token이 맞는지 확인한다.
+    if (!isSameRefreshTokenInRedis(loginId, refreshToken)) {
+      throw new IllegalArgumentException("token error");
+    }
+    User user = userRepository.findByLoginId(loginId).orElseThrow(IllegalArgumentException::new);
     String accessToken = jwtUtil.createAccessToken(user.getLoginId(), user.getUserRole());
-    return new ReissueResponse(accessToken);
+    String createdRefreshToken = jwtUtil.createRefreshToken(user.getLoginId(), user.getUserRole());
+    saveRefreshTokenToRedis(user.getLoginId(), createdRefreshToken.substring(7));
+    return new TokenResponse(accessToken, createdRefreshToken);
   }
+
+  @Override
+  @Transactional(readOnly = true)
+  public ProfileResponse getProfile(Long userId) {
+    User user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
+    return new ProfileResponse(user.getProfileImageUrl(), user.getNickname());
+  }
+
+  private void deleteRefreshTokenFromRedis(String loginId) {
+    redisDao.deleteValues(loginId);
+  }
+
+  private void saveRefreshTokenToRedis(String loginId, String refreshToken) {
+    redisDao.setValues(loginId, refreshToken,
+        Duration.ofMillis(JwtUtil.REFRESH_TOKEN_TIME));
+  }
+
+  private boolean isSameRefreshTokenInRedis(String loginId, String refreshToken) {
+    Object a = redisDao.getValues(loginId);
+    String b = a.toString();
+    return redisDao.getValues(loginId).toString().equals(refreshToken);
+  }
+
+
 }

--- a/src/main/java/com/develonity/user/service/UserServiceImpl.java
+++ b/src/main/java/com/develonity/user/service/UserServiceImpl.java
@@ -6,6 +6,7 @@ import com.develonity.user.dto.LoginRequest;
 import com.develonity.user.dto.LoginResponse;
 import com.develonity.user.dto.ProfileResponse;
 import com.develonity.user.dto.RegisterRequest;
+import com.develonity.user.dto.ReissueResponse;
 import com.develonity.user.entity.User;
 import com.develonity.user.repository.UserRepository;
 import java.time.Duration;
@@ -74,5 +75,18 @@ public class UserServiceImpl implements UserService {
   public ProfileResponse getProfile(Long userId) {
     User user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
     return new ProfileResponse(user.getProfileImageUrl(), user.getNickname());
+  }
+
+  //   RTR(refresh token rotation)을 적용하려면 현재 블랙리스트로 운영중인 refresh token 운영방식을
+//   발급시 등록하는 체제로 수정해야한다.  그럼 모든 로그인 유저의 refresh token을 redis에 등록하고 관리해야한다....'
+//   근데 RTR을 안하고 지금 방식으로 가면 refreshToken으로 무한히 많은 access token을 발급할 수 있다는 문제가 있다.
+//   RTR을 적용하면 refresh token이 탈취당하고 사용됐을 때 사용자가 서비스를 사용중이라면 알아차릴 수 있다.
+  @Override
+  public ReissueResponse reissue(String refreshToken) {
+    jwtUtil.checkBlackList(refreshToken);
+    String username = jwtUtil.getUsernameFromTokenIfValid(refreshToken);
+    User user = userRepository.findByLoginId(username).orElseThrow(IllegalArgumentException::new);
+    String accessToken = jwtUtil.createAccessToken(user.getLoginId(), user.getUserRole());
+    return new ReissueResponse(accessToken);
   }
 }

--- a/src/main/java/com/develonity/user/service/UserServiceImpl.java
+++ b/src/main/java/com/develonity/user/service/UserServiceImpl.java
@@ -45,9 +45,7 @@ public class UserServiceImpl implements UserService {
     if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
       throw new IllegalArgumentException("비밀번호 불일치");
     }
-    if (user.isWithdrawal()) {
-      throw new IllegalArgumentException("이미 탈퇴된 회원입니다.");
-    }
+
     String accessToken = jwtUtil.createAccessToken(user.getLoginId(), user.getUserRole());
     String refreshToken = jwtUtil.createRefreshToken(user.getLoginId(), user.getUserRole());
     return new LoginResponse(accessToken, refreshToken);
@@ -75,6 +73,6 @@ public class UserServiceImpl implements UserService {
   @Override
   public ProfileResponse getProfile(Long userId) {
     User user = userRepository.findById(userId).orElseThrow(IllegalArgumentException::new);
-    return new ProfileResponse(user.getProfileImageUrl(), user.getNickName());
+    return new ProfileResponse(user.getProfileImageUrl(), user.getNickname());
   }
 }


### PR DESCRIPTION
1. access token 만료시 /reissue 통해서 재발급 받도록 로직수정
2. 기존 blackList 방식(로그아웃하면 refresh token을 redis에 등록)에서 유저별로 가장 최근에 발급된 refresh token을 redis에 저장하는 방식으로 수정 
3. RTR(refresh token rotation) 적용

+++ 기존 방식의 문제점

 RTR을 안하고 지금 방식으로 가면 refreshToken으로 무한히 많은 access token을 발급할 수 있다는 문제가 있다.// 생각해보니 로그인 할 때마다 유효한 refreshToken이 계속 생긴다는 문제도 있다.//   RTR을 적용하면 refresh token이 탈취당하고 사용됐을 때 사용자가 서비스를 사용중이라면 알아차릴 수 있다.